### PR TITLE
Rename DynamoDB tables

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -12,4 +12,4 @@
 
 ### Deploy the infra and lambda
 1. run `npm run build` to build the zipfile with Lambda source
-2. run `npm run deploy` to deploy all the AWS stuff including if you need to update the Lambda from source.
+2. run `npm run deploy -- --profile=YOUR_CDK_PROFILE` to deploy all the AWS stuff including if you need to update the Lambda from source.

--- a/cdk/lib/dynamodb-stack.ts
+++ b/cdk/lib/dynamodb-stack.ts
@@ -11,7 +11,7 @@ export class DynamoDBStack extends Stack {
     super(scope, id, props);
 
     this.userDataTable = new dynamodb.Table(this, 'UserDataTable', {
-      tableName: "UserData",
+      tableName: "GitBot_UserData",
       partitionKey: {name: 'slack_user_id', type: dynamodb.AttributeType.STRING},
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       timeToLiveAttribute: 'expiry',
@@ -19,7 +19,7 @@ export class DynamoDBStack extends Stack {
     });
 
     this.stateTable = new dynamodb.Table(this, 'StateTable', {
-      tableName: "State",
+      tableName: "GitBot_State",
       partitionKey: {name: 'nonce', type: dynamodb.AttributeType.STRING},
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       timeToLiveAttribute: 'expiry',
@@ -27,7 +27,7 @@ export class DynamoDBStack extends Stack {
     });
 
     this.projectConfigTable = new dynamodb.Table(this, 'ProjectConfigTable', {
-      tableName: "ProjectConfig",
+      tableName: "GitBot_ProjectConfig",
       partitionKey: {name: 'project_id', type: dynamodb.AttributeType.NUMBER},
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: RemovalPolicy.DESTROY

--- a/lambda-src/ts-src/projectConfigTable.ts
+++ b/lambda-src/ts-src/projectConfigTable.ts
@@ -1,7 +1,7 @@
 
 import {DynamoDBClient, PutItemCommand, PutItemCommandInput, QueryCommand, QueryCommandInput, ScanCommand, ScanCommandInput} from '@aws-sdk/client-dynamodb';
 
-const TableName = "ProjectConfig";
+const TableName = "GitBot_ProjectConfig";
 
 export type ProjectConfig = {
   project_id: number,

--- a/lambda-src/ts-src/stateTable.ts
+++ b/lambda-src/ts-src/stateTable.ts
@@ -7,7 +7,7 @@ import {DynamoDBClient, PutItemCommand, PutItemCommandInput, QueryCommand, Query
 // This state should be fairly short-lived as it's just to
 // mitigage CSRF attacks on the login redirect.
 const TTL_IN_MS = 1000 * 30; // 30 seconds
-const TableName = "State";
+const TableName = "GitBot_State";
 
 export type State = {
   nonce: string,

--- a/lambda-src/ts-src/userDataTable.ts
+++ b/lambda-src/ts-src/userDataTable.ts
@@ -9,7 +9,7 @@ import {DynamoDBClient, PutItemCommand, PutItemCommandInput, QueryCommand, Query
 // If the user has accessed any functionality then the token and the TTL will
 // be refreshed so the 7 days is really 7 days after last usage.
 const TTL_IN_MS = 1000 * 60 * 60 * 24 * 7;  // 7 days
-const TableName = "UserData";
+const TableName = "GitBot_UserData";
 
 export type UserData = {
   gitlab_user_id: number,


### PR DESCRIPTION
Add GitBot prefix to DynamoDB table names to avoid clashes if deployed in the same AWS account as other projects